### PR TITLE
Avoid MissingPluginException in iOS 

### DIFF
--- a/ios/Classes/GeofencingPlugin.m
+++ b/ios/Classes/GeofencingPlugin.m
@@ -30,10 +30,8 @@ static BOOL backgroundIsolateRun = NO;
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   @synchronized(self) {
-    if (instance == nil) {
-      instance = [[GeofencingPlugin alloc] init:registrar];
-      [registrar addApplicationDelegate:instance];
-    }
+  instance = [[GeofencingPlugin alloc] init:registrar];
+  [registrar addApplicationDelegate:instance];
   }
 }
 


### PR DESCRIPTION
Register always to avoid MissingPluginException in iOS