### PR TITLE
changes to make geofence work in Android 12

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'io.flutter.plugins.geofencing'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.3.72'
+    ext.kotlin_version = '1.5.30'
 
     repositories {
         google()
@@ -26,7 +26,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 31
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingPlugin.kt
+++ b/android/src/main/kotlin/io/flutter/plugins/geofencing/GeofencingPlugin.kt
@@ -161,7 +161,11 @@ class GeofencingPlugin : ActivityAware, FlutterPlugin, MethodCallHandler {
     private fun getGeofencePendingIndent(context: Context, callbackHandle: Long): PendingIntent {
       val intent = Intent(context, GeofencingBroadcastReceiver::class.java)
               .putExtra(CALLBACK_HANDLE_KEY, callbackHandle)
-      return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE)
+      } else {
+        return PendingIntent.getBroadcast(context, 0, intent, PendingIntent.FLAG_UPDATE_CURRENT)
+      }
     }
 
     @JvmStatic


### PR DESCRIPTION
For geofencing to work in apps targeting Android 12(SDK 31) the changes in this PR is needed. 